### PR TITLE
Fix GitHub release authentication with GH_TOKEN secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,4 +168,4 @@ jobs:
         🤖 Automated release via GitHub Actions" \
           redmine-mcp-server.dxt
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**Branch Strategy**: Development work should be done on the `develop` branch. Releases are created by merging `develop` to `main`.
+
 ## Project Overview
 
 This is a Model Context Protocol (MCP) server for Redmine integration, written in TypeScript using ES modules. It enables AI assistants to interact with Redmine project management systems through a comprehensive REST API integration.


### PR DESCRIPTION
## Summary
- Fix 403 authentication error during GitHub release creation
- Replace GITHUB_TOKEN with GH_TOKEN secret for enhanced permissions
- Test the complete release workflow with proper authentication

## Changes
- Updated `.github/workflows/ci.yml` to use `GH_TOKEN` secret instead of `GITHUB_TOKEN`
- This resolves the release creation failure we encountered earlier

## Test Plan
- [x] Verify workflow syntax
- [ ] Test release creation on merge to main
- [ ] Confirm DXT file is properly attached to release

🤖 Generated with [Claude Code](https://claude.ai/code)