### PR TITLE
Update tool descriptions to specify Markdown format

### DIFF
--- a/src/tools/issues.ts
+++ b/src/tools/issues.ts
@@ -166,7 +166,7 @@ export const createIssueTool: Tool = {
       },
       description: { 
         type: 'string', 
-        description: 'Issue description' 
+        description: 'Issue description (in Markdown format)' 
       },
       tracker_id: { 
         type: 'number', 
@@ -286,11 +286,11 @@ export const updateIssueTool: Tool = {
       },
       description: { 
         type: 'string', 
-        description: 'Issue description' 
+        description: 'Issue description (in Markdown format)'
       },
-      notes: { 
-        type: 'string', 
-        description: 'Update notes/comment' 
+      notes: {
+        type: 'string',
+        description: 'Update notes/comment (in Markdown format)' 
       },
       private_notes: { 
         type: 'boolean', 

--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -143,7 +143,7 @@ export const createOrUpdateWikiPageTool: Tool = {
       },
       text: { 
         type: 'string', 
-        description: 'Wiki page content (in Textile or Markdown format)' 
+        description: 'Wiki page content (in Markdown format)' 
       },
       comments: { 
         type: 'string', 


### PR DESCRIPTION
## Summary
- Issue/wiki tool description에 Markdown 포맷 사용 안내 추가
- wiki.ts의 모호한 "Textile or Markdown" 안내를 "Markdown"으로 통일

## Test plan
- [x] `npm run build` 통과
- [x] `npm test` 54개 전체 통과
- [x] `npm run lint` 통과
- [x] develop CI (Node 20/22/24) 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)