### PR TITLE
Release v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flor3z-github/mcp-server-redmine",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flor3z-github/mcp-server-redmine",
-      "version": "1.0.8",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flor3z-github/mcp-server-redmine",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Model Context Protocol server for Redmine integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -16,6 +16,9 @@ import type {
   Tracker,
   Activity,
   Version,
+  Attachment,
+  RedmineFile,
+  Upload,
 } from './types.js';
 
 export class RedmineClient {
@@ -214,6 +217,47 @@ export class RedmineClient {
 
   async listVersions(projectId: number | string): Promise<{ versions: Version[] }> {
     const response = await this.axios.get(`/projects/${projectId}/versions.json`);
+    return response.data;
+  }
+
+  // Journals
+  async updateJournal(id: number, data: { notes?: string; private_notes?: boolean }): Promise<void> {
+    await this.axios.put(`/journals/${id}.json`, { journal: data });
+  }
+
+  // Attachments
+  async getAttachment(id: number): Promise<{ attachment: Attachment }> {
+    const response = await this.axios.get(`/attachments/${id}.json`);
+    return response.data;
+  }
+
+  async updateAttachment(id: number, data: { filename?: string; description?: string }): Promise<void> {
+    await this.axios.patch(`/attachments/${id}.json`, { attachment: data });
+  }
+
+  async deleteAttachment(id: number): Promise<void> {
+    await this.axios.delete(`/attachments/${id}.json`);
+  }
+
+  // Files
+  async listFiles(projectId: number | string): Promise<{ files: RedmineFile[] }> {
+    const response = await this.axios.get(`/projects/${projectId}/files.json`);
+    return response.data;
+  }
+
+  async createFile(projectId: number | string, data: { token: string; version_id?: number; filename?: string; description?: string }): Promise<void> {
+    await this.axios.post(`/projects/${projectId}/files.json`, { file: data });
+  }
+
+  // Uploads
+  async uploadFile(content: Buffer, filename?: string): Promise<{ upload: Upload }> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/octet-stream',
+    };
+    if (filename) {
+      headers['Content-Disposition'] = `attachment; filename="${filename}"`;
+    }
+    const response = await this.axios.post('/uploads.json', content, { headers });
     return response.data;
   }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -166,6 +166,25 @@ export interface Attachment {
   created_on: string;
 }
 
+export interface RedmineFile {
+  id: number;
+  filename: string;
+  filesize: number;
+  content_type?: string;
+  description?: string;
+  content_url: string;
+  thumbnail_url?: string;
+  author: { id: number; name: string };
+  created_on: string;
+  version?: { id: number; name: string };
+  digest: string;
+  downloads: number;
+}
+
+export interface Upload {
+  token: string;
+}
+
 export interface IssueRelation {
   id: number;
   issue_id: number;

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -1,0 +1,117 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { redmineClient } from '../client/index.js';
+import { formatAttachment } from '../utils/formatters.js';
+import { formatErrorResponse } from '../utils/errors.js';
+import { validateInput, parseId, updateAttachmentSchema } from '../utils/validators.js';
+
+// Get attachment tool
+export const getAttachmentTool: Tool = {
+  name: 'redmine_get_attachment',
+  description: 'Get detailed information about a specific attachment',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'number',
+        description: 'Attachment ID',
+      },
+    },
+    required: ['id'],
+  },
+};
+
+export async function getAttachment(input: unknown) {
+  try {
+    const { id } = input as { id: number };
+    const attachmentId = parseId(id);
+
+    const response = await redmineClient.getAttachment(attachmentId);
+    const content = formatAttachment(response.attachment);
+
+    return {
+      content: [{ type: 'text', text: content }],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatErrorResponse(error) }],
+      isError: true,
+    };
+  }
+}
+
+// Update attachment tool
+export const updateAttachmentTool: Tool = {
+  name: 'redmine_update_attachment',
+  description: 'Update an existing attachment (filename or description)',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'number',
+        description: 'Attachment ID to update',
+      },
+      filename: {
+        type: 'string',
+        description: 'New filename',
+      },
+      description: {
+        type: 'string',
+        description: 'New description',
+      },
+    },
+    required: ['id'],
+  },
+};
+
+export async function updateAttachment(input: unknown) {
+  try {
+    const { id, ...updateData } = input as { id: number; [key: string]: unknown };
+    const attachmentId = parseId(id);
+    const validatedData = validateInput(updateAttachmentSchema, updateData);
+
+    await redmineClient.updateAttachment(attachmentId, validatedData);
+
+    return {
+      content: [{ type: 'text', text: `Attachment #${attachmentId} updated successfully.` }],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatErrorResponse(error) }],
+      isError: true,
+    };
+  }
+}
+
+// Delete attachment tool
+export const deleteAttachmentTool: Tool = {
+  name: 'redmine_delete_attachment',
+  description: 'Delete an attachment from Redmine',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'number',
+        description: 'Attachment ID to delete',
+      },
+    },
+    required: ['id'],
+  },
+};
+
+export async function deleteAttachment(input: unknown) {
+  try {
+    const { id } = input as { id: number };
+    const attachmentId = parseId(id);
+
+    await redmineClient.deleteAttachment(attachmentId);
+
+    return {
+      content: [{ type: 'text', text: `Attachment #${attachmentId} deleted successfully.` }],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatErrorResponse(error) }],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -1,0 +1,138 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { redmineClient } from '../client/index.js';
+import { formatFile, formatList } from '../utils/formatters.js';
+import { formatErrorResponse } from '../utils/errors.js';
+import { validateInput, createFileSchema, uploadFileSchema } from '../utils/validators.js';
+
+// List files tool
+export const listFilesTool: Tool = {
+  name: 'redmine_list_files',
+  description: 'List files for a specific project',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      project_id: {
+        type: 'string',
+        description: 'Project ID or identifier',
+      },
+    },
+    required: ['project_id'],
+  },
+};
+
+export async function listFiles(input: unknown) {
+  try {
+    const { project_id } = input as { project_id: string | number };
+
+    const response = await redmineClient.listFiles(project_id);
+    const files = response.files || [];
+
+    let content = `Found ${files.length} file(s)\n\n`;
+
+    if (files.length > 0) {
+      content += formatList(files, formatFile);
+    } else {
+      content += 'No files found for this project.';
+    }
+
+    return {
+      content: [{ type: 'text', text: content }],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatErrorResponse(error) }],
+      isError: true,
+    };
+  }
+}
+
+// Create file tool
+export const createFileTool: Tool = {
+  name: 'redmine_create_file',
+  description: 'Add a previously uploaded file to a project',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      project_id: {
+        type: 'string',
+        description: 'Project ID or identifier',
+      },
+      token: {
+        type: 'string',
+        description: 'Upload token returned by redmine_upload_file',
+      },
+      version_id: {
+        type: 'number',
+        description: 'Version ID to associate the file with',
+      },
+      filename: {
+        type: 'string',
+        description: 'Filename to use',
+      },
+      description: {
+        type: 'string',
+        description: 'File description',
+      },
+    },
+    required: ['project_id', 'token'],
+  },
+};
+
+export async function createFile(input: unknown) {
+  try {
+    const { project_id, ...fileData } = input as { project_id: string | number; [key: string]: unknown };
+    const validatedData = validateInput(createFileSchema, fileData);
+
+    await redmineClient.createFile(project_id, validatedData);
+
+    return {
+      content: [{ type: 'text', text: `File added to project "${project_id}" successfully.` }],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatErrorResponse(error) }],
+      isError: true,
+    };
+  }
+}
+
+// Upload file tool
+export const uploadFileTool: Tool = {
+  name: 'redmine_upload_file',
+  description: 'Upload a file to Redmine and get an upload token. The token can then be used with redmine_create_file or when creating/updating issues with attachments.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      content_base64: {
+        type: 'string',
+        description: 'File content encoded as a base64 string',
+      },
+      filename: {
+        type: 'string',
+        description: 'Original filename (optional, used in Content-Disposition header)',
+      },
+    },
+    required: ['content_base64'],
+  },
+};
+
+export async function uploadFile(input: unknown) {
+  try {
+    const validatedData = validateInput(uploadFileSchema, input);
+    const content = Buffer.from(validatedData.content_base64, 'base64');
+
+    const response = await redmineClient.uploadFile(content, validatedData.filename);
+
+    return {
+      content: [{
+        type: 'text',
+        text: `File uploaded successfully!\nToken: ${response.upload.token}\n\nUse this token with redmine_create_file or when creating/updating issues with attachments.`,
+      }],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatErrorResponse(error) }],
+      isError: true,
+    };
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -60,6 +60,29 @@ import {
   deleteWikiPage,
 } from './wiki.js';
 
+import {
+  updateJournalTool,
+  updateJournal,
+} from './journals.js';
+
+import {
+  getAttachmentTool,
+  updateAttachmentTool,
+  deleteAttachmentTool,
+  getAttachment,
+  updateAttachment,
+  deleteAttachment,
+} from './attachments.js';
+
+import {
+  listFilesTool,
+  createFileTool,
+  uploadFileTool,
+  listFiles,
+  createFile,
+  uploadFile,
+} from './files.js';
+
 // Add custom API request tool
 export const customRequestTool: Tool = {
   name: 'redmine_custom_request',
@@ -303,6 +326,19 @@ export const tools: Tool[] = [
   createOrUpdateWikiPageTool,
   deleteWikiPageTool,
 
+  // Journal tools
+  updateJournalTool,
+
+  // Attachment tools
+  getAttachmentTool,
+  updateAttachmentTool,
+  deleteAttachmentTool,
+
+  // File tools
+  listFilesTool,
+  createFileTool,
+  uploadFileTool,
+
   // Custom request tool
   customRequestTool,
 
@@ -348,6 +384,19 @@ export const toolHandlers: Record<string, (_input?: unknown) => Promise<unknown>
   redmine_get_wiki_page: getWikiPage,
   redmine_create_or_update_wiki_page: createOrUpdateWikiPage,
   redmine_delete_wiki_page: deleteWikiPage,
+
+  // Journal handlers
+  redmine_update_journal: updateJournal,
+
+  // Attachment handlers
+  redmine_get_attachment: getAttachment,
+  redmine_update_attachment: updateAttachment,
+  redmine_delete_attachment: deleteAttachment,
+
+  // File handlers
+  redmine_list_files: listFiles,
+  redmine_create_file: createFile,
+  redmine_upload_file: uploadFile,
 
   // Custom request handler
   redmine_custom_request: customRequest,

--- a/src/tools/journals.ts
+++ b/src/tools/journals.ts
@@ -1,0 +1,47 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { redmineClient } from '../client/index.js';
+import { formatErrorResponse } from '../utils/errors.js';
+import { validateInput, parseId, updateJournalSchema } from '../utils/validators.js';
+
+// Update journal tool
+export const updateJournalTool: Tool = {
+  name: 'redmine_update_journal',
+  description: 'Update an existing journal (comment) on an issue',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'number',
+        description: 'Journal ID to update',
+      },
+      notes: {
+        type: 'string',
+        description: 'Updated journal notes/comment (in Markdown format)',
+      },
+      private_notes: {
+        type: 'boolean',
+        description: 'Whether the notes are private',
+      },
+    },
+    required: ['id'],
+  },
+};
+
+export async function updateJournal(input: unknown) {
+  try {
+    const { id, ...updateData } = input as { id: number; [key: string]: unknown };
+    const journalId = parseId(id);
+    const validatedData = validateInput(updateJournalSchema, updateData);
+
+    await redmineClient.updateJournal(journalId, validatedData);
+
+    return {
+      content: [{ type: 'text', text: `Journal #${journalId} updated successfully.` }],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatErrorResponse(error) }],
+      isError: true,
+    };
+  }
+}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,4 +1,6 @@
 import type {
+  Attachment,
+  RedmineFile,
   RedmineIssue,
   RedmineProject,
   RedmineUser,
@@ -132,6 +134,54 @@ export function formatWikiPage(page: WikiPage): string {
 
   if (page.text) {
     parts.push(`\nContent:\n${page.text}`);
+  }
+
+  return parts.join('\n');
+}
+
+export function formatAttachment(attachment: Attachment): string {
+  const parts = [
+    `Attachment #${attachment.id}`,
+    `Filename: ${attachment.filename}`,
+    `Size: ${attachment.filesize} bytes`,
+    `URL: ${attachment.content_url}`,
+    `Author: ${attachment.author.name}`,
+    `Created: ${attachment.created_on}`,
+  ];
+
+  if (attachment.content_type) {
+    parts.push(`Type: ${attachment.content_type}`);
+  }
+
+  if (attachment.description) {
+    parts.push(`Description: ${attachment.description}`);
+  }
+
+  return parts.join('\n');
+}
+
+export function formatFile(file: RedmineFile): string {
+  const parts = [
+    `File #${file.id}`,
+    `Filename: ${file.filename}`,
+    `Size: ${file.filesize} bytes`,
+    `URL: ${file.content_url}`,
+    `Author: ${file.author.name}`,
+    `Created: ${file.created_on}`,
+    `Downloads: ${file.downloads}`,
+    `Digest: ${file.digest}`,
+  ];
+
+  if (file.content_type) {
+    parts.push(`Type: ${file.content_type}`);
+  }
+
+  if (file.description) {
+    parts.push(`Description: ${file.description}`);
+  }
+
+  if (file.version) {
+    parts.push(`Version: ${file.version.name}`);
   }
 
   return parts.join('\n');

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -97,6 +97,32 @@ export const wikiPageSchema = z.object({
   parent_title: z.string().optional(),
 });
 
+// Journal validators
+export const updateJournalSchema = z.object({
+  notes: z.string().optional(),
+  private_notes: z.boolean().optional(),
+});
+
+// Attachment validators
+export const updateAttachmentSchema = z.object({
+  filename: z.string().min(1).optional(),
+  description: z.string().optional(),
+});
+
+// File validators
+export const createFileSchema = z.object({
+  token: z.string().min(1),
+  version_id: positiveIntegerSchema.optional(),
+  filename: z.string().optional(),
+  description: z.string().optional(),
+});
+
+// Upload validators
+export const uploadFileSchema = z.object({
+  content_base64: z.string().min(1),
+  filename: z.string().optional(),
+});
+
 // Generic pagination validator
 export const paginationSchema = z.object({
   offset: z.number().int().min(0).default(0),

--- a/test/unit/client.test.ts
+++ b/test/unit/client.test.ts
@@ -33,6 +33,7 @@ describe('RedmineClient', () => {
       get: vi.fn(),
       post: vi.fn(),
       put: vi.fn(),
+      patch: vi.fn(),
       delete: vi.fn(),
       request: vi.fn(),
       interceptors: {
@@ -361,6 +362,138 @@ describe('RedmineClient', () => {
       expect(mockAxiosInstance.get).toHaveBeenCalledWith(
         '/projects/test-project/wiki/Home/2.json'
       );
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('updateJournal', () => {
+    it('should update a journal', async () => {
+      mockAxiosInstance.put.mockResolvedValue({ data: {} });
+
+      await client.updateJournal(10, { notes: 'Updated note', private_notes: true });
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/journals/10.json', {
+        journal: { notes: 'Updated note', private_notes: true },
+      });
+    });
+  });
+
+  describe('getAttachment', () => {
+    it('should fetch attachment details', async () => {
+      const mockResponse = {
+        data: {
+          attachment: {
+            id: 1,
+            filename: 'test.txt',
+            filesize: 1024,
+            content_url: 'https://redmine.example.com/attachments/download/1/test.txt',
+            author: { id: 1, name: 'John' },
+            created_on: '2024-01-15',
+          },
+        },
+      };
+
+      mockAxiosInstance.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getAttachment(1);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/attachments/1.json');
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('updateAttachment', () => {
+    it('should update an attachment via PATCH', async () => {
+      mockAxiosInstance.patch.mockResolvedValue({ data: {} });
+
+      await client.updateAttachment(1, { filename: 'renamed.txt', description: 'Updated' });
+
+      expect(mockAxiosInstance.patch).toHaveBeenCalledWith('/attachments/1.json', {
+        attachment: { filename: 'renamed.txt', description: 'Updated' },
+      });
+    });
+  });
+
+  describe('deleteAttachment', () => {
+    it('should delete an attachment', async () => {
+      mockAxiosInstance.delete.mockResolvedValue({ data: {} });
+
+      await client.deleteAttachment(1);
+
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/attachments/1.json');
+    });
+  });
+
+  describe('listFiles', () => {
+    it('should fetch project files', async () => {
+      const mockResponse = {
+        data: {
+          files: [
+            { id: 1, filename: 'doc.pdf', filesize: 2048 },
+          ],
+        },
+      };
+
+      mockAxiosInstance.get.mockResolvedValue(mockResponse);
+
+      const result = await client.listFiles('test-project');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/projects/test-project/files.json');
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('createFile', () => {
+    it('should create a file in project', async () => {
+      mockAxiosInstance.post.mockResolvedValue({ data: {} });
+
+      await client.createFile('test-project', { token: 'abc123', version_id: 1, filename: 'doc.pdf' });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/projects/test-project/files.json', {
+        file: { token: 'abc123', version_id: 1, filename: 'doc.pdf' },
+      });
+    });
+  });
+
+  describe('uploadFile', () => {
+    it('should upload file with octet-stream content type', async () => {
+      const mockResponse = {
+        data: {
+          upload: { token: 'upload-token-123' },
+        },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue(mockResponse);
+
+      const content = Buffer.from('file content');
+      const result = await client.uploadFile(content, 'test.txt');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/uploads.json', content, {
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Disposition': 'attachment; filename="test.txt"',
+        },
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should upload file without filename', async () => {
+      const mockResponse = {
+        data: {
+          upload: { token: 'upload-token-456' },
+        },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue(mockResponse);
+
+      const content = Buffer.from('file content');
+      const result = await client.uploadFile(content);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/uploads.json', content, {
+        headers: {
+          'Content-Type': 'application/octet-stream',
+        },
+      });
       expect(result).toEqual(mockResponse.data);
     });
   });

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -27,6 +27,17 @@ import {
   createOrUpdateWikiPage,
   deleteWikiPage 
 } from '../../src/tools/wiki.js';
+import { updateJournal } from '../../src/tools/journals.js';
+import {
+  getAttachment,
+  updateAttachment,
+  deleteAttachment,
+} from '../../src/tools/attachments.js';
+import {
+  listFiles,
+  createFile,
+  uploadFile,
+} from '../../src/tools/files.js';
 import { redmineClient } from '../../src/client/index.js';
 
 // Mock the client
@@ -57,6 +68,13 @@ vi.mock('../../src/client/index.js', () => ({
     listIssuePriorities: vi.fn(),
     listTrackers: vi.fn(),
     customRequest: vi.fn(),
+    updateJournal: vi.fn(),
+    getAttachment: vi.fn(),
+    updateAttachment: vi.fn(),
+    deleteAttachment: vi.fn(),
+    listFiles: vi.fn(),
+    createFile: vi.fn(),
+    uploadFile: vi.fn(),
   },
 }));
 
@@ -676,6 +694,210 @@ describe('Wiki Tools', () => {
 
       expect(redmineClient.deleteWikiPage).toHaveBeenCalledWith('test', 'OldPage');
       expect(result.content[0].text).toContain('Wiki page "OldPage" deleted successfully');
+    });
+  });
+});
+
+describe('Journal Tools', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('updateJournal', () => {
+    it('should update a journal', async () => {
+      vi.mocked(redmineClient.updateJournal).mockResolvedValue(undefined);
+
+      const result = await updateJournal({
+        id: 10,
+        notes: 'Updated comment',
+        private_notes: true,
+      });
+
+      expect(redmineClient.updateJournal).toHaveBeenCalledWith(10, {
+        notes: 'Updated comment',
+        private_notes: true,
+      });
+      expect(result.content[0].text).toContain('Journal #10 updated successfully');
+    });
+
+    it('should handle errors', async () => {
+      vi.mocked(redmineClient.updateJournal).mockRejectedValue(new Error('Not found'));
+
+      const result = await updateJournal({ id: 999 });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error: Not found');
+    });
+  });
+});
+
+describe('Attachment Tools', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAttachment', () => {
+    it('should get attachment details', async () => {
+      const mockAttachment = {
+        attachment: {
+          id: 1,
+          filename: 'test.pdf',
+          filesize: 2048,
+          content_type: 'application/pdf',
+          content_url: 'https://redmine.example.com/attachments/download/1/test.pdf',
+          author: { id: 1, name: 'John Doe' },
+          created_on: '2024-01-15',
+          description: 'A test file',
+        },
+      };
+
+      vi.mocked(redmineClient.getAttachment).mockResolvedValue(mockAttachment);
+
+      const result = await getAttachment({ id: 1 });
+
+      expect(redmineClient.getAttachment).toHaveBeenCalledWith(1);
+      expect(result.content[0].text).toContain('Attachment #1');
+      expect(result.content[0].text).toContain('Filename: test.pdf');
+      expect(result.content[0].text).toContain('Size: 2048 bytes');
+      expect(result.content[0].text).toContain('Author: John Doe');
+      expect(result.content[0].text).toContain('Description: A test file');
+    });
+
+    it('should handle errors', async () => {
+      vi.mocked(redmineClient.getAttachment).mockRejectedValue(new Error('Not found'));
+
+      const result = await getAttachment({ id: 999 });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe('updateAttachment', () => {
+    it('should update an attachment', async () => {
+      vi.mocked(redmineClient.updateAttachment).mockResolvedValue(undefined);
+
+      const result = await updateAttachment({
+        id: 1,
+        filename: 'renamed.pdf',
+        description: 'Updated description',
+      });
+
+      expect(redmineClient.updateAttachment).toHaveBeenCalledWith(1, {
+        filename: 'renamed.pdf',
+        description: 'Updated description',
+      });
+      expect(result.content[0].text).toContain('Attachment #1 updated successfully');
+    });
+  });
+
+  describe('deleteAttachment', () => {
+    it('should delete an attachment', async () => {
+      vi.mocked(redmineClient.deleteAttachment).mockResolvedValue(undefined);
+
+      const result = await deleteAttachment({ id: 1 });
+
+      expect(redmineClient.deleteAttachment).toHaveBeenCalledWith(1);
+      expect(result.content[0].text).toContain('Attachment #1 deleted successfully');
+    });
+  });
+});
+
+describe('File Tools', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listFiles', () => {
+    it('should list project files', async () => {
+      const mockFiles = {
+        files: [
+          {
+            id: 1,
+            filename: 'doc.pdf',
+            filesize: 4096,
+            content_url: 'https://redmine.example.com/attachments/download/1/doc.pdf',
+            author: { id: 1, name: 'Jane Doe' },
+            created_on: '2024-01-15',
+            downloads: 5,
+            digest: 'abc123',
+          },
+        ],
+      };
+
+      vi.mocked(redmineClient.listFiles).mockResolvedValue(mockFiles);
+
+      const result = await listFiles({ project_id: 'test-project' });
+
+      expect(redmineClient.listFiles).toHaveBeenCalledWith('test-project');
+      expect(result.content[0].text).toContain('Found 1 file(s)');
+      expect(result.content[0].text).toContain('File #1');
+      expect(result.content[0].text).toContain('Filename: doc.pdf');
+      expect(result.content[0].text).toContain('Downloads: 5');
+    });
+
+    it('should handle empty results', async () => {
+      vi.mocked(redmineClient.listFiles).mockResolvedValue({ files: [] });
+
+      const result = await listFiles({ project_id: 'empty-project' });
+
+      expect(result.content[0].text).toContain('No files found');
+    });
+  });
+
+  describe('createFile', () => {
+    it('should create a file in project', async () => {
+      vi.mocked(redmineClient.createFile).mockResolvedValue(undefined);
+
+      const result = await createFile({
+        project_id: 'test-project',
+        token: 'upload-token-123',
+        version_id: 1,
+        filename: 'release.zip',
+      });
+
+      expect(redmineClient.createFile).toHaveBeenCalledWith('test-project', {
+        token: 'upload-token-123',
+        version_id: 1,
+        filename: 'release.zip',
+      });
+      expect(result.content[0].text).toContain('File added to project "test-project" successfully');
+    });
+
+    it('should validate required token', async () => {
+      const result = await createFile({
+        project_id: 'test-project',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
+    });
+  });
+
+  describe('uploadFile', () => {
+    it('should upload file and return token', async () => {
+      vi.mocked(redmineClient.uploadFile).mockResolvedValue({
+        upload: { token: 'returned-token-789' },
+      });
+
+      const base64Content = Buffer.from('test file content').toString('base64');
+      const result = await uploadFile({
+        content_base64: base64Content,
+        filename: 'test.txt',
+      });
+
+      expect(redmineClient.uploadFile).toHaveBeenCalledWith(
+        Buffer.from(base64Content, 'base64'),
+        'test.txt'
+      );
+      expect(result.content[0].text).toContain('File uploaded successfully');
+      expect(result.content[0].text).toContain('Token: returned-token-789');
+    });
+
+    it('should validate required content_base64', async () => {
+      const result = await uploadFile({});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Validation error');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add 7 new MCP tools for Journals, Attachments, Files, and Uploads APIs
- New tools: `redmine_update_journal`, `redmine_get_attachment`, `redmine_update_attachment`, `redmine_delete_attachment`, `redmine_list_files`, `redmine_create_file`, `redmine_upload_file`
- Includes types, client methods, formatters, validators, and comprehensive tests
- Bump version to v1.1.0

## Test plan
- [x] `npm run build` — TypeScript compiles successfully
- [x] `npm run lint` — ESLint passes
- [x] `npm test` — All 74 tests pass
- [x] CI passes on Node.js 20.x, 22.x, 24.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)