### PR TITLE
Improve CI pipeline reliability and npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Run linter
       run: npm run lint
@@ -49,6 +49,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -63,7 +66,7 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Build project
       run: npm run build
@@ -81,8 +84,8 @@ jobs:
           echo "changed=false" >> $GITHUB_OUTPUT
         fi
 
-    - name: Publish to npm
+    - name: Publish to npm with provenance
       if: steps.version-check.outputs.changed == 'true'
-      run: npm publish
+      run: npm publish --access public --provenance
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Use `npm ci` instead of `npm install` in CI for reproducible builds
- Add `permissions` block and `--provenance` flag to publish job for npm provenance support

## Test plan
- [ ] Verify CI pipeline runs successfully with `npm ci`
- [ ] Verify npm publish with provenance works on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)