### PR TITLE
Release v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ See [USAGE.md](USAGE.md) for detailed configuration, Docker deployment, and reve
 
 All tools are prefixed with `redmine_` (e.g., `redmine_list_issues`).
 
+## Breaking Changes
+
+### `redmine_get_issue` — Comments Now Opt-in
+
+**Issue comments are no longer returned by default.** To retrieve comments, use one of:
+- `include_journals=true` — returns comments with pagination control via `journals_limit`, `journals_offset`, `journals_order`
+- `include: ["journals"]` — same effect, unless `include_journals` is explicitly set to `false`
+
+For details and new pagination parameters, see [docs/API.md](docs/API.md#redmine_get_issue).
+
 ## Installation
 
 ```bash

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,19 +46,20 @@ Gets detailed information about a specific issue.
 
 **Parameters:**
 - `id` (number, required): Issue ID
-- `include` (array, optional): Additional data to include
-  - `"journals"`: Issue history and comments
-  - `"watchers"`: Users watching the issue
-  - `"relations"`: Related issues
-  - `"children"`: Sub-tasks
-  - `"attachments"`: File attachments
-  - `"changesets"`: Associated commits
+- `include_journals` (boolean, default `false`) — return comment bodies. When false, only the comment count is shown.
+- `journals_limit` (number, 1–100, default 10), `journals_offset` (number, default 0), `journals_order` (`"desc"` default = newest first | `"asc"` = oldest first)
+- `description_max_chars` (number, `0`/omit = full), `journal_notes_max_chars` (number, default 500, `0` = full)
+- `include` (string[]) — `watchers`, `relations`, `children`, `attachments`, `changesets`. Listing `journals` here also enables comments unless `include_journals` is set.
+
+> **Breaking change:** comments are no longer returned by default. Pass `include_journals=true` (or `include: ["journals"]`).
 
 **Example:**
 ```json
 {
   "id": 123,
-  "include": ["journals", "attachments"]
+  "include_journals": true,
+  "journals_limit": 20,
+  "include": ["attachments"]
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-13-get-issue-token-pagination.md
+++ b/docs/superpowers/plans/2026-07-13-get-issue-token-pagination.md
@@ -1,0 +1,714 @@
+# get_issue Token Reduction & Comment Pagination — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `redmine_get_issue` cheap by default — comments opt-in, paginated, and length-capped — while adding input validation.
+
+**Architecture:** The token cost is controlled at the tool/formatter layer. The Redmine client still fetches the full issue (Redmine has no per-issue journal pagination); a pure formatter slices/truncates before returning to the model. `getIssue` gains a validated schema; `formatIssue` gains an options object; a new pure `formatJournals` renders the comment window.
+
+**Tech Stack:** TypeScript (ES modules), Zod validation, Vitest, `@modelcontextprotocol/sdk`.
+
+## Global Constraints
+
+- Node ES modules — all local imports use `.js` extension (e.g. `../client/types.js`).
+- No `any` types.
+- Team-internal fork — breaking changes allowed; no backward-compat guarantee for external npm consumers.
+- Test coverage threshold: 80% (lines/functions/branches/statements).
+- `npm test` runs Vitest in **watch** mode. Always use `npx vitest run <file>` for one-shot runs in these steps.
+- Korean/multibyte text: truncation uses JS `substring` (UTF-16 code units), safe for BMP (Korean). Reuse existing `truncateText`.
+- Commit style: conventional commits, end body with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- `src/utils/formatters.ts` (modify) — add `FormatIssueOptions` interface, add exported pure `formatJournals`, extend `formatIssue` to accept options. Add `Journal` to the type import.
+- `test/unit/formatters.test.ts` (create) — unit tests for `formatJournals` and `formatIssue` truncation.
+- `src/utils/validators.ts` (modify) — add exported `getIssueSchema`.
+- `src/tools/issues.ts` (modify) — add local `buildInclude` helper; rewrite `getIssueTool.inputSchema` (7 params) and `getIssue` handler to validate + map options.
+- `test/unit/tools.test.ts` (modify) — extend the existing `describe('getIssue')` block with new behavior tests.
+- `README.md` / `docs/API.md` (modify) — document new params + breaking change.
+
+**No changes** to `src/client/index.ts` (its `getIssue(id, include[])` is reused as-is) or `src/client/types.ts` (`Journal` type already fits).
+
+---
+
+## Task 1: Formatter options + `formatJournals` pure function
+
+**Files:**
+- Modify: `src/utils/formatters.ts:1-57`
+- Test: `test/unit/formatters.test.ts` (create)
+
+**Interfaces:**
+- Consumes: existing `truncateText(text, maxLength)`, `Journal` type from `../client/types.js`.
+- Produces:
+  ```ts
+  export interface FormatIssueOptions {
+    descriptionMaxChars?: number;   // undefined/0 => unlimited
+    includeJournals?: boolean;      // default false
+    journalsLimit?: number;         // default 10
+    journalsOffset?: number;        // default 0
+    journalsOrder?: 'asc' | 'desc'; // default 'desc' (offset 0 = newest)
+    journalNotesMaxChars?: number;  // undefined/0 => unlimited
+  }
+  export function formatJournals(journals: Journal[] | undefined, opts?: FormatIssueOptions): string;
+  export function formatIssue(issue: RedmineIssue, opts?: FormatIssueOptions): string;
+  ```
+  Behavior contract for `formatJournals`:
+  - `journals === undefined` (not fetched) → `''` (no line at all — preserves list/create/update output).
+  - fetched but zero note-bearing journals → `'\nComments: none'`.
+  - `includeJournals` falsy → `'\nComments: N total (not shown — pass include_journals=true)'`.
+  - `journalsOffset >= total` → `'\nComments: N total (offset K exceeds range)'`.
+  - else → header `'\nComments: N total (showing A-B, newest first|oldest first)'` + one line per windowed comment; each note over the cap is truncated with a drill-down marker.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/formatters.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { formatJournals, formatIssue } from '../../src/utils/formatters.js';
+import type { Journal, RedmineIssue } from '../../src/client/types.js';
+
+function journal(id: number, notes?: string): Journal {
+  return {
+    id,
+    user: { id: 1, name: `User${id}` },
+    notes,
+    created_on: `2026-07-1${id}T00:00:00Z`,
+    private_notes: false,
+  };
+}
+
+describe('formatJournals', () => {
+  it('returns empty string when journals not fetched (undefined)', () => {
+    expect(formatJournals(undefined)).toBe('');
+  });
+
+  it('returns "Comments: none" when fetched but no note-bearing journals', () => {
+    expect(formatJournals([journal(1), journal(2, '   ')])).toBe('\nComments: none');
+  });
+
+  it('shows only the count when includeJournals is false', () => {
+    const js = [journal(1, 'a'), journal(2, 'b'), journal(3, 'c')];
+    expect(formatJournals(js, { includeJournals: false })).toBe(
+      '\nComments: 3 total (not shown — pass include_journals=true)'
+    );
+  });
+
+  it('counts only note-bearing journals', () => {
+    const js = [journal(1, 'has note'), journal(2), journal(3, 'also note')];
+    const out = formatJournals(js, { includeJournals: false });
+    expect(out).toContain('2 total');
+  });
+
+  it('renders newest first by default and respects limit', () => {
+    const js = [journal(1, 'oldest'), journal(2, 'middle'), journal(3, 'newest')];
+    const out = formatJournals(js, { includeJournals: true, journalsLimit: 2 });
+    expect(out).toContain('Comments: 3 total (showing 0-1, newest first)');
+    expect(out).toContain('newest');
+    expect(out).toContain('middle');
+    expect(out).not.toContain('oldest');
+  });
+
+  it('honors ascending order', () => {
+    const js = [journal(1, 'oldest'), journal(2, 'newest')];
+    const out = formatJournals(js, { includeJournals: true, journalsOrder: 'asc', journalsLimit: 1 });
+    expect(out).toContain('oldest first');
+    expect(out).toContain('oldest');
+    expect(out).not.toContain('newest');
+  });
+
+  it('applies offset window', () => {
+    const js = [journal(1, 'c0-old'), journal(2, 'c1'), journal(3, 'c2-new')];
+    const out = formatJournals(js, { includeJournals: true, journalsOffset: 1, journalsLimit: 1 });
+    // desc order: [c2-new, c1, c0-old]; offset 1 => c1
+    expect(out).toContain('showing 1-1');
+    expect(out).toContain('c1');
+    expect(out).not.toContain('c2-new');
+    expect(out).not.toContain('c0-old');
+  });
+
+  it('reports out-of-range offset', () => {
+    const js = [journal(1, 'a'), journal(2, 'b')];
+    const out = formatJournals(js, { includeJournals: true, journalsOffset: 5 });
+    expect(out).toBe('\nComments: 2 total (offset 5 exceeds range)');
+  });
+
+  it('truncates long notes and appends a drill-down marker', () => {
+    const long = 'x'.repeat(50);
+    const js = [journal(1, long)];
+    const out = formatJournals(js, { includeJournals: true, journalNotesMaxChars: 10 });
+    expect(out).toContain('xxxxxxxxxx …(+40 chars truncated');
+    expect(out).toContain('journals_offset=0 journals_limit=1 journal_notes_max_chars=0 for full');
+  });
+
+  it('does not truncate when cap is 0 (unlimited escape hatch)', () => {
+    const long = 'y'.repeat(50);
+    const js = [journal(1, long)];
+    const out = formatJournals(js, { includeJournals: true, journalNotesMaxChars: 0 });
+    expect(out).toContain(long);
+    expect(out).not.toContain('truncated');
+  });
+});
+
+describe('formatIssue with options', () => {
+  const baseIssue = {
+    id: 1,
+    subject: 'S',
+    project: { name: 'P' },
+    status: { name: 'New' },
+    priority: { name: 'Normal' },
+    author: { name: 'A' },
+    done_ratio: 0,
+    description: 'D'.repeat(1000),
+  } as unknown as RedmineIssue;
+
+  it('returns full description when no cap given', () => {
+    const out = formatIssue(baseIssue);
+    expect(out).toContain('D'.repeat(1000));
+  });
+
+  it('truncates description when descriptionMaxChars set', () => {
+    const out = formatIssue(baseIssue, { descriptionMaxChars: 100 });
+    expect(out).not.toContain('D'.repeat(200));
+    expect(out).toContain('...');
+  });
+
+  it('omits any Comments line when issue has no journals field', () => {
+    const out = formatIssue(baseIssue);
+    expect(out).not.toContain('Comments');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/unit/formatters.test.ts`
+Expected: FAIL — `formatJournals` is not exported / `formatIssue` ignores options.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/utils/formatters.ts`, update the type import at the top (line 1-9) to add `Journal`:
+
+```ts
+import type {
+  Attachment,
+  Journal,
+  RedmineFile,
+  RedmineIssue,
+  RedmineProject,
+  RedmineUser,
+  TimeEntry,
+  WikiPage,
+} from '../client/types.js';
+```
+
+Replace the whole `formatIssue` function (lines 11-57) with:
+
+```ts
+export interface FormatIssueOptions {
+  descriptionMaxChars?: number;
+  includeJournals?: boolean;
+  journalsLimit?: number;
+  journalsOffset?: number;
+  journalsOrder?: 'asc' | 'desc';
+  journalNotesMaxChars?: number;
+}
+
+export function formatJournals(
+  journals: Journal[] | undefined,
+  opts: FormatIssueOptions = {}
+): string {
+  if (journals === undefined) {
+    return '';
+  }
+
+  const withNotes = journals.filter(
+    (j) => typeof j.notes === 'string' && j.notes.trim().length > 0
+  );
+  const total = withNotes.length;
+  if (total === 0) {
+    return '\nComments: none';
+  }
+
+  if (!opts.includeJournals) {
+    return `\nComments: ${total} total (not shown — pass include_journals=true)`;
+  }
+
+  const order = opts.journalsOrder ?? 'desc';
+  const ordered = order === 'desc' ? [...withNotes].reverse() : [...withNotes];
+
+  const offset = opts.journalsOffset ?? 0;
+  const limit = opts.journalsLimit ?? 10;
+  if (offset >= total) {
+    return `\nComments: ${total} total (offset ${offset} exceeds range)`;
+  }
+
+  const windowed = ordered.slice(offset, offset + limit);
+  const shownEnd = offset + windowed.length - 1;
+  const orderLabel = order === 'desc' ? 'newest first' : 'oldest first';
+  const noteCap = opts.journalNotesMaxChars ?? 0;
+
+  const lines = [
+    `\nComments: ${total} total (showing ${offset}-${shownEnd}, ${orderLabel})`,
+  ];
+
+  windowed.forEach((j, i) => {
+    const absoluteIndex = offset + i;
+    const fullNote = j.notes as string;
+    let note = fullNote;
+    let marker = '';
+    if (noteCap > 0 && fullNote.length > noteCap) {
+      const cut = fullNote.length - noteCap;
+      note = fullNote.substring(0, noteCap);
+      marker =
+        ` …(+${cut} chars truncated, journals_offset=${absoluteIndex} ` +
+        `journals_limit=1 journal_notes_max_chars=0 for full)`;
+    }
+    lines.push(`- ${j.user.name} (${j.created_on}): ${note}${marker}`);
+  });
+
+  return lines.join('\n');
+}
+
+export function formatIssue(issue: RedmineIssue, opts: FormatIssueOptions = {}): string {
+  const parts = [
+    `#${issue.id} - ${issue.subject}`,
+    `Project: ${issue.project.name}`,
+    `Status: ${issue.status.name}`,
+    `Priority: ${issue.priority.name}`,
+    `Author: ${issue.author.name}`,
+  ];
+
+  if (issue.assigned_to) {
+    parts.push(`Assigned to: ${issue.assigned_to.name}`);
+  }
+
+  if (issue.done_ratio > 0) {
+    parts.push(`Progress: ${issue.done_ratio}%`);
+  }
+
+  if (issue.due_date) {
+    parts.push(`Due date: ${issue.due_date}`);
+  }
+
+  if (issue.description) {
+    const desc =
+      opts.descriptionMaxChars && opts.descriptionMaxChars > 0
+        ? truncateText(issue.description, opts.descriptionMaxChars)
+        : issue.description;
+    parts.push(`\nDescription:\n${desc}`);
+  }
+
+  if (issue.start_date) {
+    parts.push(`Start date: ${issue.start_date}`);
+  }
+
+  if (issue.fixed_version) {
+    parts.push(`Version: ${issue.fixed_version.name}`);
+  }
+
+  const journalsText = formatJournals(issue.journals, opts);
+  if (journalsText) {
+    parts.push(journalsText);
+  }
+
+  return parts.join('\n');
+}
+```
+
+Note: `truncateText` is defined later in the same file (function hoisting makes this safe). The duplicate `due_date` push from the original (lines 40-42) is intentionally dropped.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run test/unit/formatters.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Verify no regression in existing tool tests**
+
+Run: `npx vitest run test/unit/tools.test.ts`
+Expected: PASS — existing `getIssue`, `listIssues`, `createIssue`, `updateIssue` tests unaffected (they call `formatIssue(issue)` with no journals field → no Comments line; list still truncates via its own regex).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/formatters.ts test/unit/formatters.test.ts
+git commit -m "$(cat <<'EOF'
+feat(formatters): add formatJournals with pagination and note truncation
+
+Extend formatIssue with a FormatIssueOptions object and a new pure
+formatJournals function that windows/orders comments and caps note length.
+Undefined journals render nothing (preserves list/create/update output).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Validated schema + `getIssue` handler with comment controls
+
+**Files:**
+- Modify: `src/utils/validators.ts` (add `getIssueSchema` after the issue validators block)
+- Modify: `src/tools/issues.ts:104-150` (tool schema + handler) and imports (line 3)
+- Test: `test/unit/tools.test.ts:140-188` (extend existing `describe('getIssue')`)
+
+**Interfaces:**
+- Consumes: `formatIssue` + `FormatIssueOptions` (Task 1), `validateInput`, `positiveIntegerSchema` from `../utils/validators.js`, `redmineClient.getIssue(id, include)`.
+- Produces:
+  ```ts
+  // validators.ts
+  export const getIssueSchema: z.ZodType<{
+    id: number;
+    include_journals?: boolean;
+    journals_limit: number;
+    journals_offset: number;
+    journals_order: 'asc' | 'desc';
+    description_max_chars?: number;
+    journal_notes_max_chars: number;
+    include?: string[];
+  }>;
+  // issues.ts (local, not exported)
+  function buildInclude(userInclude?: string[]): { include: string[]; journalsRequested: boolean };
+  ```
+  Bridge precedence in the handler: `const includeJournals = params.include_journals ?? journalsRequested;`
+  (`include_journals` has NO zod default, so an explicit `false` is preserved and wins; omitted → inferred from the `include` array; neither → `false`.)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe('getIssue', () => { ... })` block in `test/unit/tools.test.ts` (before its closing `});` at line 188):
+
+```ts
+    it('does not render comments by default, but shows the count', async () => {
+      const mockIssue = {
+        issue: {
+          id: 200,
+          subject: 'Has comments',
+          project: { name: 'P' },
+          status: { name: 'New' },
+          priority: { name: 'Normal' },
+          author: { name: 'U' },
+          done_ratio: 0,
+          journals: [
+            { id: 1, user: { id: 1, name: 'A' }, notes: 'first', created_on: '2026-07-01T00:00:00Z', private_notes: false },
+            { id: 2, user: { id: 2, name: 'B' }, notes: 'second', created_on: '2026-07-02T00:00:00Z', private_notes: false },
+          ],
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 200 });
+
+      expect(result.content[0].text).toContain('Comments: 2 total (not shown');
+      expect(result.content[0].text).not.toContain('first');
+      expect(result.content[0].text).not.toContain('second');
+    });
+
+    it('renders comments when include_journals is true', async () => {
+      const mockIssue = {
+        issue: {
+          id: 201, subject: 'S', project: { name: 'P' }, status: { name: 'New' },
+          priority: { name: 'Normal' }, author: { name: 'U' }, done_ratio: 0,
+          journals: [
+            { id: 1, user: { id: 1, name: 'A' }, notes: 'older', created_on: '2026-07-01T00:00:00Z', private_notes: false },
+            { id: 2, user: { id: 2, name: 'B' }, notes: 'newer', created_on: '2026-07-02T00:00:00Z', private_notes: false },
+          ],
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 201, include_journals: true });
+
+      expect(result.content[0].text).toContain('showing 0-1, newest first');
+      expect(result.content[0].text).toContain('newer');
+      expect(result.content[0].text).toContain('older');
+    });
+
+    it('truncates description when description_max_chars is set', async () => {
+      const mockIssue = {
+        issue: {
+          id: 202, subject: 'S', project: { name: 'P' }, status: { name: 'New' },
+          priority: { name: 'Normal' }, author: { name: 'U' }, done_ratio: 0,
+          description: 'Z'.repeat(1000),
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 202, description_max_chars: 50 });
+
+      expect(result.content[0].text).toContain('...');
+      expect(result.content[0].text).not.toContain('Z'.repeat(200));
+    });
+
+    it('bridges include:[journals] to render comments', async () => {
+      const mockIssue = {
+        issue: {
+          id: 203, subject: 'S', project: { name: 'P' }, status: { name: 'New' },
+          priority: { name: 'Normal' }, author: { name: 'U' }, done_ratio: 0,
+          journals: [
+            { id: 1, user: { id: 1, name: 'A' }, notes: 'bridged', created_on: '2026-07-01T00:00:00Z', private_notes: false },
+          ],
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 203, include: ['journals'] });
+
+      expect(result.content[0].text).toContain('bridged');
+    });
+
+    it('lets explicit include_journals=false override the include bridge', async () => {
+      const mockIssue = {
+        issue: {
+          id: 204, subject: 'S', project: { name: 'P' }, status: { name: 'New' },
+          priority: { name: 'Normal' }, author: { name: 'U' }, done_ratio: 0,
+          journals: [
+            { id: 1, user: { id: 1, name: 'A' }, notes: 'hidden', created_on: '2026-07-01T00:00:00Z', private_notes: false },
+          ],
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 204, include: ['journals'], include_journals: false });
+
+      expect(result.content[0].text).not.toContain('hidden');
+      expect(result.content[0].text).toContain('not shown');
+    });
+
+    it('returns an error response when a param is out of range', async () => {
+      const result = await getIssue({ id: 205, journals_limit: 999 });
+      expect(result.isError).toBe(true);
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run test/unit/tools.test.ts -t getIssue`
+Expected: FAIL — new params ignored / no validation yet.
+
+- [ ] **Step 3a: Add the schema to `src/utils/validators.ts`**
+
+Insert after the `issueQuerySchema` definition (search for `export const issueQuerySchema` and add below its closing `});`):
+
+```ts
+// Get-issue validator (comment pagination + truncation controls)
+export const getIssueSchema = z.object({
+  id: positiveIntegerSchema,
+  include_journals: z.boolean().optional(), // no default: preserves explicit false for bridge precedence
+  journals_limit: z.number().int().min(1).max(100).optional().default(10),
+  journals_offset: z.number().int().min(0).optional().default(0),
+  journals_order: z.enum(['asc', 'desc']).optional().default('desc'),
+  description_max_chars: z.number().int().min(0).optional(),
+  journal_notes_max_chars: z.number().int().min(0).optional().default(500),
+  include: z.array(z.string()).optional(),
+});
+```
+
+- [ ] **Step 3b: Rewrite the tool schema + handler in `src/tools/issues.ts`**
+
+Update the import on line 5-11 to add `getIssueSchema`:
+
+```ts
+import {
+  validateInput,
+  parseId,
+  createIssueSchema,
+  updateIssueSchema,
+  issueQuerySchema,
+  getIssueSchema,
+} from '../utils/validators.js';
+```
+
+Replace `getIssueTool` and `getIssue` (lines 104-150) with:
+
+```ts
+// Get issue tool
+export const getIssueTool: Tool = {
+  name: 'redmine_get_issue',
+  description:
+    'Get a specific issue. Comments (journals) are OFF by default to save tokens; ' +
+    'the total count is always shown. Enable and page through comments with the journals_* params.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'number',
+        description: 'Issue ID',
+      },
+      include_journals: {
+        type: 'boolean',
+        description: 'Return comment bodies (default false). When false, only the total count is shown.',
+      },
+      journals_limit: {
+        type: 'number',
+        description: 'Max comments to return when include_journals=true (1-100, default 10)',
+      },
+      journals_offset: {
+        type: 'number',
+        description: 'Comment start index for paging (default 0; with desc order, 0 = newest)',
+      },
+      journals_order: {
+        type: 'string',
+        description: '"desc" (newest first, default) or "asc" (oldest first)',
+      },
+      description_max_chars: {
+        type: 'number',
+        description: 'Truncate the description to this many chars. Omit or 0 = full text.',
+      },
+      journal_notes_max_chars: {
+        type: 'number',
+        description: 'Truncate each comment to this many chars (default 500). 0 = full text.',
+      },
+      include: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Extra data besides journals: watchers, relations, children, attachments, changesets. ' +
+          "Passing 'journals' here also turns comments on unless include_journals is explicitly set.",
+      },
+    },
+    required: ['id'],
+  },
+};
+
+function buildInclude(userInclude?: string[]): { include: string[]; journalsRequested: boolean } {
+  const requested = userInclude ?? [];
+  const journalsRequested = requested.includes('journals');
+  const others = requested.filter((v) => v !== 'journals');
+  return { include: ['journals', ...others], journalsRequested };
+}
+
+export async function getIssue(input: unknown) {
+  try {
+    const params = validateInput(getIssueSchema, input);
+    const { include, journalsRequested } = buildInclude(params.include);
+    const includeJournals = params.include_journals ?? journalsRequested;
+
+    const response = await redmineClient.getIssue(params.id, include);
+    const content = formatIssue(response.issue, {
+      descriptionMaxChars: params.description_max_chars,
+      includeJournals,
+      journalsLimit: params.journals_limit,
+      journalsOffset: params.journals_offset,
+      journalsOrder: params.journals_order,
+      journalNotesMaxChars: params.journal_notes_max_chars,
+    });
+
+    return {
+      content: [{ type: 'text', text: content }],
+    };
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatErrorResponse(error) }],
+      isError: true,
+    };
+  }
+}
+```
+
+Note: `parseId` is no longer used by `getIssue` (schema validates `id`), but it is still used by other handlers in this file — leave the import.
+
+- [ ] **Step 4: Run the getIssue tests to verify they pass**
+
+Run: `npx vitest run test/unit/tools.test.ts -t getIssue`
+Expected: PASS — including the two pre-existing tests (`should get issue details` still asserts client called with `(123, ['journals'])`; `should include additional data when requested` still asserts `(123, ['journals', 'attachments'])`).
+
+- [ ] **Step 5: Run the full suite + build**
+
+Run: `npx vitest run`
+Expected: PASS, coverage ≥ 80%.
+
+Run: `npm run build`
+Expected: `tsc` exits clean, no type errors. (If `tsc` is missing, run `npm ci` first.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/validators.ts src/tools/issues.ts test/unit/tools.test.ts
+git commit -m "$(cat <<'EOF'
+feat(get_issue): comments opt-in, paginated, and validated
+
+redmine_get_issue no longer force-dumps every comment. journals are OFF by
+default (count still shown), with journals_limit/offset/order paging,
+description_max_chars, and journal_notes_max_chars caps. Adds a getIssueSchema
+for input validation. include:['journals'] bridges to on unless include_journals
+is explicitly set.
+
+BREAKING: comments are no longer returned unless include_journals=true (or
+include contains 'journals').
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Document the new parameters and breaking change
+
+**Files:**
+- Modify: `README.md` (tools table / get_issue entry)
+- Modify: `docs/API.md` (get_issue section)
+
+**Interfaces:**
+- Consumes: final param list from Task 2.
+- Produces: no code.
+
+- [ ] **Step 1: Locate the get_issue docs**
+
+Run: `grep -rn "redmine_get_issue\|get_issue" README.md docs/API.md`
+Expected: one or more references to update.
+
+- [ ] **Step 2: Update the docs**
+
+In `README.md` and `docs/API.md`, update the `redmine_get_issue` description to state: comments are OFF by default (only the count is shown); enable with `include_journals=true`; page with `journals_limit` / `journals_offset` / `journals_order`; cap text with `description_max_chars` / `journal_notes_max_chars` (0 = unlimited). Add a short **Breaking change** note: previously all comments were always returned.
+
+Concrete snippet to insert under the get_issue docs (adapt heading level to the file):
+
+```markdown
+**`redmine_get_issue`** — Get one issue.
+
+- `id` (number, required)
+- `include_journals` (boolean, default `false`) — return comment bodies. When false, only the comment count is shown.
+- `journals_limit` (number, 1–100, default 10), `journals_offset` (number, default 0), `journals_order` (`"desc"` default | `"asc"`)
+- `description_max_chars` (number, `0`/omit = full), `journal_notes_max_chars` (number, default 500, `0` = full)
+- `include` (string[]) — `watchers`, `relations`, `children`, `attachments`, `changesets`. Listing `journals` here also enables comments unless `include_journals` is set.
+
+> **Breaking change:** comments are no longer returned by default. Pass `include_journals=true` (or `include: ["journals"]`).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/API.md
+git commit -m "$(cat <<'EOF'
+docs: document get_issue comment pagination params and breaking change
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- comments opt-in (default OFF) → Task 2 handler (`includeJournals` default false) + Task 1 formatter. ✓
+- always show count → Task 1 `formatJournals` count meta. ✓
+- offset/limit/order pagination → Task 1 + Task 2 params. ✓
+- description/note truncation with 0=unlimited → Task 1 (`descriptionMaxChars`, `journalNotesMaxChars`). ✓
+- drill-down escape hatch marker → Task 1 truncation marker test. ✓
+- input validation (getIssueSchema) → Task 2 Step 3a + out-of-range test. ✓
+- bridge precedence (explicit include_journals > include-array > false) → Task 2 handler `?? ` + two tests. ✓
+- total counts note-bearing only → Task 1 "counts only note-bearing" test. ✓
+- backward-safe for list/create/update (undefined journals → no line) → Task 1 undefined test + Task 1 Step 5 regression run. ✓
+- docs/breaking-change note → Task 3. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step has full code; every test has assertions. ✓
+
+**3. Type consistency:** `FormatIssueOptions` field names (`descriptionMaxChars`, `includeJournals`, `journalsLimit`, `journalsOffset`, `journalsOrder`, `journalNotesMaxChars`) are identical in Task 1's interface, Task 1's `formatIssue`/`formatJournals` bodies, and Task 2's handler mapping. Schema snake_case params (`include_journals`, `journals_limit`, `journals_offset`, `journals_order`, `description_max_chars`, `journal_notes_max_chars`) match between Task 2 schema, tool inputSchema, and tests. `buildInclude` returns `{ include, journalsRequested }` used verbatim in the handler. ✓
+
+**Deviation from spec (noted):** Spec §5 suggested `formatIssue` opts default `includeJournals=true` for backward safety. The plan instead makes `formatJournals` return `''` for `journals === undefined`, which preserves list/create/update output more precisely and lets the default be `false`. Same outcome, cleaner.

--- a/docs/superpowers/specs/2026-07-13-get-issue-token-pagination-design.md
+++ b/docs/superpowers/specs/2026-07-13-get-issue-token-pagination-design.md
@@ -1,0 +1,267 @@
+# get_issue 토큰 절감 · 코멘트 페이지네이션 설계
+
+- **날짜:** 2026-07-13
+- **대상:** `redmine_get_issue` MCP 도구
+- **브랜치:** `develop` (릴리즈 시 `main`으로 머지)
+- **범위:** 팀 내부 전용 fork — 파괴적 변경 허용
+
+## 1. 배경 / 문제
+
+`redmine_get_issue`가 이슈 하나당 과도한 토큰을 소비한다. 실측:
+
+- 회의록형 이슈(#34861) 1회 조회 = 약 6,600자 → **~5,000 토큰**
+- `list_issues` 5건(~900 토큰)의 5배 이상
+
+원인 (코드 확인):
+
+1. **코멘트 강제 포함.** `src/tools/issues.ts`의 `getIssue` 핸들러가 `journals`를 include에 강제 주입한다. 호출자가 원치 않아도 코멘트 전량이 반환된다.
+   ```ts
+   // 현재 코드
+   if (!include) include = ['journals'];
+   else if (!include.includes('journals')) include = [...include, 'journals'];
+   ```
+2. **truncate 부재.** `formatIssue`가 description 전체 + 모든 journal note를 상한 없이 렌더링한다.
+3. **입력 검증 부재.** `getIssue`는 zod 검증 없이 raw cast만 한다.
+
+이 팀은 회의록·장애분석을 코멘트에 통째로 붙이는 사용 패턴이 있어, 코멘트 하나가 수천 자에 이르는 경우가 잦다.
+
+### 왜 도구 레이어에서 해결하는가
+
+토큰 비용은 도구가 결과를 **반환하는 순간** 컨텍스트에 적재되며 발생한다. 스킬은 모델 추론 내에서 "어떤 도구를 무슨 인자로 부를지"를 결정할 뿐, 이미 반환된 페이로드를 사후 축소하지 못한다. 게다가 현재 구조는 journals를 강제하므로 스킬 단독으로는 코멘트 반환을 막을 수 없다. 따라서 페이로드 제어는 도구/서버 레이어에 있어야 한다. (스킬은 파라미터가 열린 뒤 그 위에 얹는 "호출 규율" 레이어로서 보완적이다 — 본 설계 범위 밖.)
+
+Redmine 코어 API는 issue 내 journals를 페이지네이션하지 않는다. `GET /issues/:id.json?include=journals`는 전체 journal을 한 번에 반환한다. 따라서 "끊어 읽기"는 서버가 전체를 fetch한 뒤 **모델에 넘길 때 슬라이스**하는 방식으로 구현한다. 서버↔Redmine 네트워크는 전량 그대로지만(내부망이라 무시 가능), 절감 대상인 **모델 컨텍스트 토큰**은 제어된다.
+
+## 2. 목표 / 비목표
+
+**목표:**
+- get_issue 기본 호출을 경량화(코멘트 기본 미포함)
+- 코멘트를 offset/limit으로 끊어 읽기(페이지네이션)
+- 본문·개별 코멘트 길이 상한(옵션)
+- 필요 시 전문 회수 가능한 탈출구 제공
+- 입력 검증 추가
+
+**비목표:**
+- 하위호환 유지 (팀 내부 전용, 파괴적 변경 허용)
+- 별도 스킬 작성 (후속 과제)
+- 다른 도구(`list_issues` 등) 변경
+- Redmine 서버측 페이지네이션 (코어 API 미지원)
+
+## 2.5 기대 이득 (ROI)
+
+절감폭은 호출 패턴에 따라 다르다. 이슈는 대략 2종류다.
+
+**본문형** (#34861: 본문 큼, 코멘트 적음) — 현재 ~5,000 토큰:
+
+| 새 호출 | 토큰 | 절감 |
+|---|---|---|
+| 기본(본문 전체 + 코멘트 OFF) | ~4,000 | 20% |
+| 스캔(`description_max_chars=500` + 코멘트 OFF) | ~400 | 92% |
+
+→ 본문형은 코멘트 OFF만으로는 이득이 작다(범인이 본문). 트리아지 시 `description_max_chars`를 써야 크게 남는다.
+
+**토론형** (본문 작음, 코멘트 30개) — 현재 ~9,700 토큰:
+
+| 새 호출 | 토큰 | 절감 |
+|---|---|---|
+| 기본(코멘트 OFF) | ~750 | 92% |
+| 본문 + 최신 10개(cap 500) | ~3,500 | 64% |
+| 전체 드릴다운 | ~9,700 | 0% (명시적 선택) |
+
+→ 토론형은 기본값만으로 ~90% 절감.
+
+**세션 단위** (디버깅 중 이슈 10개 탐색):
+
+- 현재: 10 × 평균 ~4,000 = **~40,000 토큰**
+- 신설계: 트리아지 스캔 10개(×~400) + 정독 1~2개 ≈ **~12,000 토큰**
+- **탐색 비용 ~70% 절감**
+
+**핵심 가치:** 최악의 경우가 "무한 → 상한"으로 바뀐다. 코멘트 30개 이슈가 조용히 1만 토큰을 먹는 사고 원천을 차단한다.
+
+**한계 (정직한 명시):**
+1. `get_issue`만 개선 — `list`/`search`는 이미 truncate되어 무관.
+2. 고정비 소폭 증가(파라미터 2→7개, 스키마 수백 토큰). `defer_loading` 환경에선 무시 가능하며 응답 절감이 압도.
+3. 본문형은 자동 절감 안 됨 — 호출자(모델/스킬)가 `description_max_chars`를 실제로 써야 큰 이득.
+
+## 3. API 설계
+
+### 시그니처
+
+```
+redmine_get_issue(
+  id: number,                               // 필수
+  include_journals?: boolean = false,       // 코멘트 반환 여부 (기존 강제ON → 기본OFF)
+  journals_limit?: number = 10,             // 코멘트 페이지 크기 (1~100)
+  journals_offset?: number = 0,             // 코멘트 시작점 (≥0, 끊어 읽기)
+  journals_order?: 'asc' | 'desc' = 'desc', // 정렬 (desc=최신부터, offset=0이 최신)
+  description_max_chars?: number,           // 본문 상한. 미지정/0 = 무제한
+  journal_notes_max_chars?: number = 500,   // 각 코멘트 note 상한. 0 = 무제한(탈출구)
+  include?: string[]                        // journals 외 부가데이터
+)                                           // watchers/relations/children/attachments/changesets
+```
+
+### 동작
+
+- 서버는 Redmine에 **항상 journals 포함**(+요청된 다른 include)으로 fetch → 코멘트 총개수 확보.
+- **본문:** `description_max_chars` 지정 시 truncate, 아니면 전체.
+- **코멘트:**
+  - `include_journals=false`(기본): 코멘트 본문 미포함. 메타만 표시.
+    - 예: `Comments: 47 total (not shown — pass include_journals=true)`
+  - `include_journals=true`: note 있는 항목만 필터 → `journals_order` 정렬 → `[offset, offset+limit)` 슬라이스 → 각 note를 `journal_notes_max_chars`로 컷.
+    - 메타: `Comments: 47 total (showing 0–9, newest first)`
+    - 컷 마커: `…(+4200 chars 잘림, journals_offset=3 journals_limit=1 journal_notes_max_chars=0 로 전문)`
+
+### `include` 처리 (브릿지 방식)
+
+`include` 배열은 journals 외 부가데이터(watchers 등)용. journals는 전용 파라미터가 관장하되, 하위 호출 놀람 방지를 위해 브릿지:
+
+- 우선순위: **명시적 `include_journals` > `include` 배열의 `'journals'` 추론 > 기본 `false`**
+- 즉 `include=['journals']`만 넘기면 `include_journals=true`로 해석. 단 `include_journals=false`를 명시하면 그것이 우선(코멘트 미표시).
+- Redmine 요청용 include에는 journals를 항상 강제 주입하고 사용자 배열의 중복 journals는 제거(dedup).
+
+### 동작 예시
+
+| 호출 | 결과 |
+|---|---|
+| `get_issue(34861)` | 본문 전체 + `Comments: 1 total (not shown…)`. 코멘트 ~0토큰 |
+| `get_issue(34861, include_journals=true)` | 본문 + 최신 10개(각 500자 컷) |
+| `get_issue(34861, include_journals=true, journals_offset=10)` | 본문 + 11~20번째 |
+| `get_issue(34861, description_max_chars=500, include_journals=true, journals_limit=3)` | 본문 500자 + 최신 3개. 초경량 |
+| `get_issue(34861, include_journals=true, journals_offset=3, journals_limit=1, journal_notes_max_chars=0)` | 3번 코멘트 전문(드릴다운) |
+| `get_issue(34861, include=['journals'])` | 브릿지 → 최신 10개 |
+
+## 4. 데이터 흐름
+
+```
+MCP 호출
+  ▼
+[1] 검증  validateInput(getIssueSchema, input)   ← 신규(현재 무검증)
+  │   범위: limit 1~100, offset ≥0, *_max_chars ≥0, order enum
+  ▼
+[2] include 조립  buildInclude(userInclude)
+  │   Redmine엔 ['journals', ...나머지], 사용자 journals 중복 제거
+  │   include 배열의 journals 존재 → includeJournals 추론(브릿지)
+  ▼
+[3] client.getIssue(id, include)  ──HTTP──▶ Redmine ◀── journals 전량
+  ▼
+[4] formatIssue(issue, opts)
+  │   본문: descriptionMaxChars 컷
+  │   formatJournals(journals, opts):
+  │     a. note 있는 항목만 필터
+  │     b. total = 필터된 개수  ← "코멘트 N개"의 N
+  │     c. order=desc → 복사 후 역순
+  │     d. includeJournals=false → 본문 생략, 메타만
+  │        =true → [offset, offset+limit) 슬라이스, note컷+마커
+  ▼
+[5] text 반환
+```
+
+**서브결정:**
+1. `total`은 **note 달린 코멘트만** 카운트(상태변경-only 항목 제외) — 사용자 멘탈모델과 일치.
+2. 슬라이싱은 `formatIssue`/`formatJournals`가 opts 받아 처리 — 이미 journal 렌더링 담당.
+
+## 5. 구현 분해
+
+### `src/utils/validators.ts` — 신규 스키마
+
+```ts
+export const getIssueSchema = z.object({
+  id: positiveIntegerSchema,
+  include_journals: z.boolean().optional().default(false),
+  journals_limit: z.number().int().min(1).max(100).optional().default(10),
+  journals_offset: z.number().int().min(0).optional().default(0),
+  journals_order: z.enum(['asc', 'desc']).optional().default('desc'),
+  description_max_chars: z.number().int().min(0).optional(),
+  journal_notes_max_chars: z.number().int().min(0).optional().default(500),
+  include: z.array(z.string()).optional(),
+});
+```
+
+### `src/utils/formatters.ts` — `formatIssue` 확장 + `formatJournals` 신규(export)
+
+```ts
+export interface FormatIssueOptions {
+  descriptionMaxChars?: number;    // 미지정/0 = 무제한
+  includeJournals?: boolean;       // 기본 true (기존 호출부 안전)
+  journalsLimit?: number;
+  journalsOffset?: number;
+  journalsOrder?: 'asc' | 'desc';
+  journalNotesMaxChars?: number;   // 미지정/0 = 무제한
+}
+
+export function formatIssue(issue: RedmineIssue, opts?: FormatIssueOptions): string;
+export function formatJournals(journals: Journal[] | undefined, opts?: FormatIssueOptions): string;
+```
+
+- 기본 `opts = {}` → `includeJournals` 기본 true, 상한 없음 → **기존 4개 호출부(list/get/create/update) 무변경**. (list/create/update가 넘기는 issue엔 journals가 없어 무해.)
+- `formatJournals`는 순수함수 → 단위테스트 용이.
+- 마커·메타 문자열 생성은 `formatJournals` 내부.
+
+### `src/tools/issues.ts` — 도구 스키마 + 핸들러 + 헬퍼
+
+```ts
+// getIssueTool.inputSchema (JSON, MCP용): 파라미터 7개 + description 문서화
+//   (기존 관례: 손으로 쓴 JSON inputSchema와 zod 스키마 이중 유지)
+
+function buildInclude(userInclude?: string[]): { include: string[]; journalsRequested: boolean }
+// journals 강제 주입 + dedup, 사용자 배열의 journals 존재 여부 반환(브릿지용)
+
+export async function getIssue(input: unknown) {
+  const p = validateInput(getIssueSchema, input);
+  const { include, journalsRequested } = buildInclude(p.include);
+  // 브릿지 우선순위: 입력에 include_journals 명시 → 그 값 / 아니면 journalsRequested / 아니면 false
+  const includeJournals = /* 명시 여부 판별 */;
+  const res = await redmineClient.getIssue(p.id, include);
+  const text = formatIssue(res.issue, {
+    descriptionMaxChars: p.description_max_chars,
+    includeJournals,
+    journalsLimit: p.journals_limit,
+    journalsOffset: p.journals_offset,
+    journalsOrder: p.journals_order,
+    journalNotesMaxChars: p.journal_notes_max_chars,
+  });
+  return { content: [{ type: 'text', text }] };
+}
+```
+
+**브릿지 구현 주의:** zod의 `.default(false)`가 걸리면 "명시 안 함"과 "false 명시"를 구별 못 한다. 원본 input에서 `include_journals` 키 존재 여부를 검증 전에 확인하거나, 스키마에서 default를 빼고 핸들러에서 3단 우선순위를 계산한다. (구현 계획에서 확정.)
+
+### 변경 없음
+
+- `src/client/index.ts` — `getIssue(id, include[])` 그대로.
+- `src/client/types.ts` — `Journal`(notes/user/created_on) 기존 타입 사용.
+
+## 6. 엣지케이스
+
+| 상황 | 동작 |
+|---|---|
+| `*_max_chars = 0` / 미지정 | 무제한(전체) |
+| `journals_offset ≥ total` | 코멘트 0개 + `Comments: 47 total (offset 50 exceeds range)` |
+| journals 없음 | `Comments: none` |
+| note 없는 항목(상태변경-only) | count·표시 제외 |
+| `include_journals=false` + limit/offset 지정 | 무시(코멘트 미표시) |
+| `order=desc` | 배열 복사 후 역순(원본 불변) |
+| note 컷 경계 | 한글 BMP → `substring` 안전, 기존 `truncateText` 재사용 |
+
+**Redmine 에러(404/403 등):** client throw → 기존 retry/`formatErrorResponse` 경로. 변경 없음.
+
+## 7. 테스트 계획
+
+- `test/unit/tools.test.ts` (get_issue):
+  - 기본 호출 → 코멘트 본문 미포함, 총개수 메타 존재
+  - `include_journals=true` → limit 개수만 반환
+  - `journals_offset` → 올바른 구간 반환
+  - `journals_order=asc/desc` → 정렬 방향 확인
+  - `description_max_chars` → 본문 컷 확인
+  - `journal_notes_max_chars` → note 컷 + 마커
+  - `include=['journals']` 브릿지 → 코멘트 반환
+  - `include_journals=false` 명시 + `include=['journals']` → 코멘트 미반환(우선순위)
+  - 검증 실패(limit 범위 초과 등) → 에러 응답
+- `test/unit/formatters.test.ts`(신규 또는 기존): `formatJournals` 순수함수 단위테스트
+  - note-only 필터, count, order, slice, note컷, offset 초과, journals 없음
+- 커버리지 80% 임계 유지.
+
+## 8. 마이그레이션 / 롤아웃
+
+- `develop`에서 작업 → 검증 → PR로 `main` 머지(릴리즈).
+- 파괴적 변경(코멘트 기본 OFF, `include` 배열 journals 의미 변경) → CHANGELOG/README에 명시.
+- 버전: minor bump (기능 추가 + 동작 변경). 예 `1.x.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flor3z-github/mcp-server-redmine",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flor3z-github/mcp-server-redmine",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flor3z-github/mcp-server-redmine",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Model Context Protocol server for Redmine integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
 
-// Buffer compatibility polyfill for Node.js environments
-if (Buffer.prototype && !Buffer.prototype.subarray) {
-  Buffer.prototype.subarray = Buffer.prototype.slice;
-}
-
 import { runServer } from './server.js';
 import { SERVER_VERSION } from './version.js';
 

--- a/src/tools/issues.ts
+++ b/src/tools/issues.ts
@@ -2,12 +2,13 @@ import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { redmineClient } from '../client/index.js';
 import { formatIssue, formatList, truncateText } from '../utils/formatters.js';
 import { formatErrorResponse } from '../utils/errors.js';
-import { 
-  validateInput, 
+import {
+  validateInput,
   parseId,
   createIssueSchema,
   updateIssueSchema,
-  issueQuerySchema 
+  issueQuerySchema,
+  getIssueSchema,
 } from '../utils/validators.js';
 import type { RedmineIssue } from '../client/types.js';
 import type { z } from 'zod';
@@ -104,47 +105,82 @@ export async function listIssues(input: unknown) {
 // Get issue tool
 export const getIssueTool: Tool = {
   name: 'redmine_get_issue',
-  description: 'Get detailed information about a specific issue',
+  description:
+    'Get a specific issue. Comments (journals) are OFF by default to save tokens; ' +
+    'the total count is always shown. Enable and page through comments with the journals_* params.',
   inputSchema: {
     type: 'object',
     properties: {
-      id: { 
-        type: 'number', 
-        description: 'Issue ID' 
+      id: {
+        type: 'number',
+        description: 'Issue ID',
+      },
+      include_journals: {
+        type: 'boolean',
+        description: 'Return comment bodies (default false). When false, only the total count is shown.',
+      },
+      journals_limit: {
+        type: 'number',
+        description: 'Max comments to return when include_journals=true (1-100, default 10)',
+      },
+      journals_offset: {
+        type: 'number',
+        description: 'Comment start index for paging (default 0; with desc order, 0 = newest)',
+      },
+      journals_order: {
+        type: 'string',
+        description: '"desc" (newest first, default) or "asc" (oldest first)',
+      },
+      description_max_chars: {
+        type: 'number',
+        description: 'Truncate the description to this many chars. Omit or 0 = full text.',
+      },
+      journal_notes_max_chars: {
+        type: 'number',
+        description: 'Truncate each comment to this many chars (default 500). 0 = full text.',
       },
       include: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Additional data to include: journals, watchers, relations, children, attachments, changesets'
-      }
+        description:
+          'Extra data besides journals: watchers, relations, children, attachments, changesets. ' +
+          "Passing 'journals' here also turns comments on unless include_journals is explicitly set.",
+      },
     },
-    required: ['id']
-  }
+    required: ['id'],
+  },
 };
+
+function buildInclude(userInclude?: string[]): { include: string[]; journalsRequested: boolean } {
+  const requested = userInclude ?? [];
+  const journalsRequested = requested.includes('journals');
+  const others = requested.filter((v) => v !== 'journals');
+  return { include: ['journals', ...others], journalsRequested };
+}
 
 export async function getIssue(input: unknown) {
   try {
-    const { id, include: inputInclude } = input as { id: number; include?: string[] };
-    const issueId = parseId(id);
+    const params = validateInput(getIssueSchema, input);
+    const { include, journalsRequested } = buildInclude(params.include);
+    const includeJournals = params.include_journals ?? journalsRequested;
 
-    // journals가 포함되어 있지 않으면 추가
-    let include = inputInclude;
-    if (!include) {
-      include = ['journals'];
-    } else if (!include.includes('journals')) {
-      include = [...include, 'journals'];
-    }
+    const response = await redmineClient.getIssue(params.id, include);
+    const content = formatIssue(response.issue, {
+      descriptionMaxChars: params.description_max_chars,
+      includeJournals,
+      journalsLimit: params.journals_limit,
+      journalsOffset: params.journals_offset,
+      journalsOrder: params.journals_order,
+      journalNotesMaxChars: params.journal_notes_max_chars,
+    });
 
-    const response = await redmineClient.getIssue(issueId, include);
-    const content = formatIssue(response.issue);
-    
     return {
-      content: [{ type: 'text', text: content }]
+      content: [{ type: 'text', text: content }],
     };
   } catch (error) {
     return {
       content: [{ type: 'text', text: formatErrorResponse(error) }],
-      isError: true
+      isError: true,
     };
   }
 }

--- a/src/transport/stdio.ts
+++ b/src/transport/stdio.ts
@@ -24,8 +24,9 @@ export async function startStdioTransport(server: Server): Promise<void> {
   // Keep process alive by maintaining event loop activity
   const keepAlive = globalThis.setInterval(() => {}, 1000000);
 
-  // Keep the process alive and handle stdin properly for MCP
-  process.stdin.setEncoding('utf8');
+  // Keep the process alive and handle stdin properly for MCP.
+  // Do NOT call setEncoding() here: it makes stdin emit strings, and the SDK's
+  // ReadBuffer requires Buffer chunks (it calls Buffer#subarray while framing).
   process.stdin.resume();
 
   // Handle stdin closure (when client disconnects)

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,5 +1,6 @@
 import type {
   Attachment,
+  Journal,
   RedmineFile,
   RedmineIssue,
   RedmineProject,
@@ -8,7 +9,72 @@ import type {
   WikiPage,
 } from '../client/types.js';
 
-export function formatIssue(issue: RedmineIssue): string {
+export interface FormatIssueOptions {
+  descriptionMaxChars?: number;
+  includeJournals?: boolean;
+  journalsLimit?: number;
+  journalsOffset?: number;
+  journalsOrder?: 'asc' | 'desc';
+  journalNotesMaxChars?: number;
+}
+
+export function formatJournals(
+  journals: Journal[] | undefined,
+  opts: FormatIssueOptions = {}
+): string {
+  if (journals === undefined) {
+    return '';
+  }
+
+  const withNotes = journals.filter(
+    (j) => typeof j.notes === 'string' && j.notes.trim().length > 0
+  );
+  const total = withNotes.length;
+  if (total === 0) {
+    return '\nComments: none';
+  }
+
+  if (!opts.includeJournals) {
+    return `\nComments: ${total} total (not shown — pass include_journals=true)`;
+  }
+
+  const order = opts.journalsOrder ?? 'desc';
+  const ordered = order === 'desc' ? [...withNotes].reverse() : [...withNotes];
+
+  const offset = opts.journalsOffset ?? 0;
+  const limit = opts.journalsLimit ?? 10;
+  if (offset >= total) {
+    return `\nComments: ${total} total (offset ${offset} exceeds range)`;
+  }
+
+  const windowed = ordered.slice(offset, offset + limit);
+  const shownEnd = offset + windowed.length - 1;
+  const orderLabel = order === 'desc' ? 'newest first' : 'oldest first';
+  const noteCap = opts.journalNotesMaxChars ?? 0;
+
+  const lines = [
+    `\nComments: ${total} total (showing ${offset}-${shownEnd}, ${orderLabel})`,
+  ];
+
+  windowed.forEach((j, i) => {
+    const absoluteIndex = offset + i;
+    const fullNote = j.notes as string;
+    let note = fullNote;
+    let marker = '';
+    if (noteCap > 0 && fullNote.length > noteCap) {
+      const cut = fullNote.length - noteCap;
+      note = fullNote.substring(0, noteCap);
+      marker =
+        ` …(+${cut} chars truncated, journals_offset=${absoluteIndex} ` +
+        `journals_limit=1 journal_notes_max_chars=0 for full)`;
+    }
+    lines.push(`- ${j.user.name} (${j.created_on}): ${note}${marker}`);
+  });
+
+  return lines.join('\n');
+}
+
+export function formatIssue(issue: RedmineIssue, opts: FormatIssueOptions = {}): string {
   const parts = [
     `#${issue.id} - ${issue.subject}`,
     `Project: ${issue.project.name}`,
@@ -30,27 +96,24 @@ export function formatIssue(issue: RedmineIssue): string {
   }
 
   if (issue.description) {
-    parts.push(`\nDescription:\n${issue.description}`);
+    const desc =
+      opts.descriptionMaxChars && opts.descriptionMaxChars > 0
+        ? truncateText(issue.description, opts.descriptionMaxChars)
+        : issue.description;
+    parts.push(`\nDescription:\n${desc}`);
   }
 
   if (issue.start_date) {
     parts.push(`Start date: ${issue.start_date}`);
   }
 
-  if (issue.due_date) {
-    parts.push(`Due date: ${issue.due_date}`);
-  }
-
   if (issue.fixed_version) {
     parts.push(`Version: ${issue.fixed_version.name}`);
   }
 
-  if (issue.journals && issue.journals.length > 0) {
-    parts.push(`\nComments:`);
-    issue.journals.forEach((journal) => {
-        if (!journal.notes) return;
-      parts.push(`- ${journal.user.name} (${journal.created_on}): ${journal.notes}`);
-    });
+  const journalsText = formatJournals(issue.journals, opts);
+  if (journalsText) {
+    parts.push(journalsText);
   }
 
   return parts.join('\n');

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -66,7 +66,7 @@ export function formatJournals(
       note = fullNote.substring(0, noteCap);
       marker =
         ` …(+${cut} chars truncated, journals_offset=${absoluteIndex} ` +
-        `journals_limit=1 journal_notes_max_chars=0 for full)`;
+        `journals_limit=1 journals_order=${order} journal_notes_max_chars=0 for full)`;
     }
     lines.push(`- ${j.user.name} (${j.created_on}): ${note}${marker}`);
   });

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -64,6 +64,18 @@ export const issueQuerySchema = z.object({
   limit: z.number().int().min(1).max(100).optional(),
 });
 
+// Get-issue validator (comment pagination + truncation controls)
+export const getIssueSchema = z.object({
+  id: positiveIntegerSchema,
+  include_journals: z.boolean().optional(), // no default: preserves explicit false for bridge precedence
+  journals_limit: z.number().int().min(1).max(100).optional().default(10),
+  journals_offset: z.number().int().min(0).optional().default(0),
+  journals_order: z.enum(['asc', 'desc']).optional().default('desc'),
+  description_max_chars: z.number().int().min(0).optional(),
+  journal_notes_max_chars: z.number().int().min(0).optional().default(500),
+  include: z.array(z.string()).optional(),
+});
+
 // Time entry validators
 const baseTimeEntrySchema = z.object({
   issue_id: positiveIntegerSchema.optional(),

--- a/test/integration/server.test.ts
+++ b/test/integration/server.test.ts
@@ -130,7 +130,7 @@ describe('Redmine MCP Server Integration', () => {
       const result = await handler({});
       expect(result).toHaveProperty('content');
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Validation error');
+      expect(result.content[0].text).toContain('Validation error: id');
     });
 
     it('should handle network errors gracefully', async () => {

--- a/test/integration/server.test.ts
+++ b/test/integration/server.test.ts
@@ -130,7 +130,7 @@ describe('Redmine MCP Server Integration', () => {
       const result = await handler({});
       expect(result).toHaveProperty('content');
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Invalid ID');
+      expect(result.content[0].text).toContain('Validation error');
     });
 
     it('should handle network errors gracefully', async () => {

--- a/test/unit/formatters.test.ts
+++ b/test/unit/formatters.test.ts
@@ -72,7 +72,7 @@ describe('formatJournals', () => {
     const js = [journal(1, long)];
     const out = formatJournals(js, { includeJournals: true, journalNotesMaxChars: 10 });
     expect(out).toContain('xxxxxxxxxx …(+40 chars truncated');
-    expect(out).toContain('journals_offset=0 journals_limit=1 journal_notes_max_chars=0 for full');
+    expect(out).toContain('journals_offset=0 journals_limit=1 journals_order=desc journal_notes_max_chars=0 for full');
   });
 
   it('does not truncate when cap is 0 (unlimited escape hatch)', () => {
@@ -81,6 +81,19 @@ describe('formatJournals', () => {
     const out = formatJournals(js, { includeJournals: true, journalNotesMaxChars: 0 });
     expect(out).toContain(long);
     expect(out).not.toContain('truncated');
+  });
+
+  it('marker reflects journals_order for asc drill-down', () => {
+    const long = 'z'.repeat(50);
+    const js = [journal(1, long), journal(2, 'short')];
+    const out = formatJournals(js, {
+      includeJournals: true,
+      journalsOrder: 'asc',
+      journalNotesMaxChars: 10,
+    });
+    // asc order keeps [j1(long), j2(short)]; offset 0 is the long note → truncated
+    expect(out).toContain('journals_order=asc');
+    expect(out).toContain('journals_offset=0');
   });
 });
 

--- a/test/unit/formatters.test.ts
+++ b/test/unit/formatters.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { formatJournals, formatIssue } from '../../src/utils/formatters.js';
+import type { Journal, RedmineIssue } from '../../src/client/types.js';
+
+function journal(id: number, notes?: string): Journal {
+  return {
+    id,
+    user: { id: 1, name: `User${id}` },
+    notes,
+    created_on: `2026-07-1${id}T00:00:00Z`,
+    private_notes: false,
+  };
+}
+
+describe('formatJournals', () => {
+  it('returns empty string when journals not fetched (undefined)', () => {
+    expect(formatJournals(undefined)).toBe('');
+  });
+
+  it('returns "Comments: none" when fetched but no note-bearing journals', () => {
+    expect(formatJournals([journal(1), journal(2, '   ')])).toBe('\nComments: none');
+  });
+
+  it('shows only the count when includeJournals is false', () => {
+    const js = [journal(1, 'a'), journal(2, 'b'), journal(3, 'c')];
+    expect(formatJournals(js, { includeJournals: false })).toBe(
+      '\nComments: 3 total (not shown — pass include_journals=true)'
+    );
+  });
+
+  it('counts only note-bearing journals', () => {
+    const js = [journal(1, 'has note'), journal(2), journal(3, 'also note')];
+    const out = formatJournals(js, { includeJournals: false });
+    expect(out).toContain('2 total');
+  });
+
+  it('renders newest first by default and respects limit', () => {
+    const js = [journal(1, 'oldest'), journal(2, 'middle'), journal(3, 'newest')];
+    const out = formatJournals(js, { includeJournals: true, journalsLimit: 2 });
+    expect(out).toContain('Comments: 3 total (showing 0-1, newest first)');
+    expect(out).toContain('newest');
+    expect(out).toContain('middle');
+    expect(out).not.toContain('oldest');
+  });
+
+  it('honors ascending order', () => {
+    const js = [journal(1, 'oldest'), journal(2, 'newest')];
+    const out = formatJournals(js, { includeJournals: true, journalsOrder: 'asc', journalsLimit: 1 });
+    expect(out).toContain('oldest first');
+    expect(out).toContain('oldest');
+    expect(out).not.toContain('newest');
+  });
+
+  it('applies offset window', () => {
+    const js = [journal(1, 'c0-old'), journal(2, 'c1'), journal(3, 'c2-new')];
+    const out = formatJournals(js, { includeJournals: true, journalsOffset: 1, journalsLimit: 1 });
+    // desc order: [c2-new, c1, c0-old]; offset 1 => c1
+    expect(out).toContain('showing 1-1');
+    expect(out).toContain('c1');
+    expect(out).not.toContain('c2-new');
+    expect(out).not.toContain('c0-old');
+  });
+
+  it('reports out-of-range offset', () => {
+    const js = [journal(1, 'a'), journal(2, 'b')];
+    const out = formatJournals(js, { includeJournals: true, journalsOffset: 5 });
+    expect(out).toBe('\nComments: 2 total (offset 5 exceeds range)');
+  });
+
+  it('truncates long notes and appends a drill-down marker', () => {
+    const long = 'x'.repeat(50);
+    const js = [journal(1, long)];
+    const out = formatJournals(js, { includeJournals: true, journalNotesMaxChars: 10 });
+    expect(out).toContain('xxxxxxxxxx …(+40 chars truncated');
+    expect(out).toContain('journals_offset=0 journals_limit=1 journal_notes_max_chars=0 for full');
+  });
+
+  it('does not truncate when cap is 0 (unlimited escape hatch)', () => {
+    const long = 'y'.repeat(50);
+    const js = [journal(1, long)];
+    const out = formatJournals(js, { includeJournals: true, journalNotesMaxChars: 0 });
+    expect(out).toContain(long);
+    expect(out).not.toContain('truncated');
+  });
+});
+
+describe('formatIssue with options', () => {
+  const baseIssue = {
+    id: 1,
+    subject: 'S',
+    project: { name: 'P' },
+    status: { name: 'New' },
+    priority: { name: 'Normal' },
+    author: { name: 'A' },
+    done_ratio: 0,
+    description: 'D'.repeat(1000),
+  } as unknown as RedmineIssue;
+
+  it('returns full description when no cap given', () => {
+    const out = formatIssue(baseIssue);
+    expect(out).toContain('D'.repeat(1000));
+  });
+
+  it('truncates description when descriptionMaxChars set', () => {
+    const out = formatIssue(baseIssue, { descriptionMaxChars: 100 });
+    expect(out).not.toContain('D'.repeat(200));
+    expect(out).toContain('...');
+  });
+
+  it('omits any Comments line when issue has no journals field', () => {
+    const out = formatIssue(baseIssue);
+    expect(out).not.toContain('Comments');
+  });
+});

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -185,6 +185,107 @@ describe('Issue Tools', () => {
         ['journals', 'attachments']
       );
     });
+
+    it('does not render comments by default, but shows the count', async () => {
+      const mockIssue = {
+        issue: {
+          id: 200,
+          subject: 'Has comments',
+          project: { name: 'P' },
+          status: { name: 'New' },
+          priority: { name: 'Normal' },
+          author: { name: 'U' },
+          done_ratio: 0,
+          journals: [
+            { id: 1, user: { id: 1, name: 'A' }, notes: 'first', created_on: '2026-07-01T00:00:00Z', private_notes: false },
+            { id: 2, user: { id: 2, name: 'B' }, notes: 'second', created_on: '2026-07-02T00:00:00Z', private_notes: false },
+          ],
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 200 });
+
+      expect(result.content[0].text).toContain('Comments: 2 total (not shown');
+      expect(result.content[0].text).not.toContain('first');
+      expect(result.content[0].text).not.toContain('second');
+    });
+
+    it('renders comments when include_journals is true', async () => {
+      const mockIssue = {
+        issue: {
+          id: 201, subject: 'S', project: { name: 'P' }, status: { name: 'New' },
+          priority: { name: 'Normal' }, author: { name: 'U' }, done_ratio: 0,
+          journals: [
+            { id: 1, user: { id: 1, name: 'A' }, notes: 'older', created_on: '2026-07-01T00:00:00Z', private_notes: false },
+            { id: 2, user: { id: 2, name: 'B' }, notes: 'newer', created_on: '2026-07-02T00:00:00Z', private_notes: false },
+          ],
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 201, include_journals: true });
+
+      expect(result.content[0].text).toContain('showing 0-1, newest first');
+      expect(result.content[0].text).toContain('newer');
+      expect(result.content[0].text).toContain('older');
+    });
+
+    it('truncates description when description_max_chars is set', async () => {
+      const mockIssue = {
+        issue: {
+          id: 202, subject: 'S', project: { name: 'P' }, status: { name: 'New' },
+          priority: { name: 'Normal' }, author: { name: 'U' }, done_ratio: 0,
+          description: 'Z'.repeat(1000),
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 202, description_max_chars: 50 });
+
+      expect(result.content[0].text).toContain('...');
+      expect(result.content[0].text).not.toContain('Z'.repeat(200));
+    });
+
+    it('bridges include:[journals] to render comments', async () => {
+      const mockIssue = {
+        issue: {
+          id: 203, subject: 'S', project: { name: 'P' }, status: { name: 'New' },
+          priority: { name: 'Normal' }, author: { name: 'U' }, done_ratio: 0,
+          journals: [
+            { id: 1, user: { id: 1, name: 'A' }, notes: 'bridged', created_on: '2026-07-01T00:00:00Z', private_notes: false },
+          ],
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 203, include: ['journals'] });
+
+      expect(result.content[0].text).toContain('bridged');
+    });
+
+    it('lets explicit include_journals=false override the include bridge', async () => {
+      const mockIssue = {
+        issue: {
+          id: 204, subject: 'S', project: { name: 'P' }, status: { name: 'New' },
+          priority: { name: 'Normal' }, author: { name: 'U' }, done_ratio: 0,
+          journals: [
+            { id: 1, user: { id: 1, name: 'A' }, notes: 'hidden', created_on: '2026-07-01T00:00:00Z', private_notes: false },
+          ],
+        },
+      };
+      vi.mocked(redmineClient.getIssue).mockResolvedValue(mockIssue);
+
+      const result = await getIssue({ id: 204, include: ['journals'], include_journals: false });
+
+      expect(result.content[0].text).not.toContain('hidden');
+      expect(result.content[0].text).toContain('not shown');
+    });
+
+    it('returns an error response when a param is out of range', async () => {
+      const result = await getIssue({ id: 205, journals_limit: 999 });
+      expect(result.isError).toBe(true);
+    });
   });
 
   describe('createIssue', () => {


### PR DESCRIPTION
## Summary

Ships the stdio message-framing fix that made the server unusable over stdio, together with the `get_issue` comment-pagination work already on `develop`.

## Highlights

**`fix(stdio)` — server never answered `initialize` (c2c60fc)**

`process.stdin.setEncoding('utf8')` made stdin emit strings instead of Buffers. The SDK's `ReadBuffer` stores the first chunk as-is and then calls `Buffer#subarray` while framing, so every inbound message threw:

```
TypeError: this._buffer.subarray is not a function
    at ReadBuffer.readMessage (.../sdk/dist/esm/shared/stdio.js:27:37)
```

The `initialize` request was never parsed, so clients (Claude Desktop among them) timed out after 60s and sent `notifications/cancelled`. Also drops the dead `Buffer.prototype.subarray` polyfill in `src/index.ts` — its condition can never be true on Node >= 20, and it looks like an earlier misdiagnosis of this same crash.

**`feat(get_issue)` — comments opt-in and paginated (e6b4ae9)**

> [!WARNING]
> **BREAKING**: `redmine_get_issue` no longer returns comments unless `include_journals=true` (or `include` contains `journals`). The comment count is still shown. Released as a minor version by maintainer decision.

Adds `journals_limit` / `journals_offset` / `journals_order` paging, `description_max_chars` and `journal_notes_max_chars` caps, and a `getIssueSchema` for input validation.

## Verification

- `npm run lint` — clean
- `npx vitest --run` — 8 files / 146 tests passing
- `npm run build` — clean
- Piped MCP handshake (`initialize` → `notifications/initialized` → `tools/list`) against the packed 1.3.0 tarball under a clean `env -i`: all steps respond correctly, `serverInfo.version` reports `1.3.0`
- Packed tarball inspected: no live `process.stdin.setEncoding` call, and `dist/version.js` is present — the published 1.2.0 tarball shipped stale artifacts with `SERVER_VERSION` hardcoded to `1.0.0`

## Release

Tagged `v1.3.0` on the version-bump commit. Merging triggers the `publish` job in `.github/workflows/ci.yml`, which publishes 1.3.0 to npm with provenance — matching the 1.2.0 release, whose provenance also records this repository at `refs/heads/main`.

Consumers on `npx @flor3z-github/mcp-server-redmine` should clear the stale npx cache after the release:

```bash
rm -rf ~/.npm/_npx/fa0582679e7e5ddd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)