### PR TITLE
ci: publish via npm trusted publisher (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
+    # Trusted publishing needs npm >= 11.5.1 and Node >= 22.14.0.
+    # Node 22 still bundles npm 10.9.x, so 24.x is the lowest line that qualifies.
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
 
@@ -101,11 +103,11 @@ jobs:
           echo "changed=false" >> $GITHUB_OUTPUT
         fi
 
+    # Authenticated by the npm trusted publisher (OIDC) via id-token: write.
+    # No token secret needed, and provenance is attached automatically.
     - name: Publish beta to npm
       if: steps.version-check.outputs.changed == 'true'
-      run: npm publish --access public --tag beta --provenance
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish --access public --tag beta
 
   publish:
     needs: test
@@ -120,10 +122,12 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Trusted publishing needs npm >= 11.5.1 and Node >= 22.14.0.
+    # Node 22 still bundles npm 10.9.x, so 24.x is the lowest line that qualifies.
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
 
@@ -148,8 +152,8 @@ jobs:
           echo "changed=false" >> $GITHUB_OUTPUT
         fi
 
+    # Authenticated by the npm trusted publisher (OIDC) via id-token: write.
+    # No token secret needed, and provenance is attached automatically.
     - name: Publish to npm with provenance
       if: steps.version-check.outputs.changed == 'true'
-      run: npm publish --access public --provenance
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish --access public


### PR DESCRIPTION
## Why

The v1.3.0 release merged cleanly but the publish job failed:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@flor3z-github%2fmcp-server-redmine
```

A 404 on `PUT` is npm's stand-in for an authorization failure — the package exists and 1.2.0 resolves fine. The `NPM_TOKEN` secret was last set on 2026-03-18 and has almost certainly expired. npm is still on 1.2.0; nothing partial was published.

## What changed

Both publish jobs now authenticate through an npm **trusted publisher** (OIDC) instead of a stored token:

- Dropped the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env block from both publish steps
- Dropped the explicit `--provenance` flag — provenance is attached automatically under OIDC
- Bumped both publish jobs from Node `20.x` to `24.x`

The `id-token: write` permission both jobs already declared is what the OIDC exchange needs, so that part was already in place.

### Why 24.x and not 22.x

Trusted publishing requires npm >= 11.5.1 and Node >= 22.14.0. The Node 22 line still bundles npm 10.9.x, so it fails the npm requirement despite meeting the Node one:

| Node | bundled npm | qualifies |
|---|---|---|
| 22.14.0 | 10.9.2 | no |
| 22.23.1 | 10.9.8 | no |
| 24.18.0 | 11.16.0 | yes |

The test matrix is untouched and still covers 20.x, 22.x, and 24.x.

## Prerequisite

A trusted publisher must be registered on npm for `@flor3z-github/mcp-server-redmine`:

| Field | Value |
|---|---|
| Publisher | GitHub Actions |
| Organization or user | `flor3z-github` |
| Repository | `redmine-mcp-server` |
| Workflow filename | `ci.yml` |
| Environment name | *(empty — no GitHub Environment is used)* |
| Allowed actions | Allow `npm publish` |

## Effect on merge

`main` is already at 1.3.0 while npm serves 1.2.0, so the `publish` job's version check reports `changed=true` and 1.3.0 publishes on merge. No re-run of the earlier failed workflow is needed.

Once this lands and 1.3.0 is out, the `NPM_TOKEN` secret can be deleted — nothing references it anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)